### PR TITLE
fix relation in fmt-jpa.go

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -52,4 +52,5 @@ const (
 	FlagUniqueNameSuffix = "uniqueNameSuffix"
 	FlagUseComments      = "comments"
 	FlagUseUTC           = "useUTC"
+	FlagIgnoreUnknownRelation = "ignoreUnknownRelation"
 )

--- a/fmt-jpa.go
+++ b/fmt-jpa.go
@@ -318,7 +318,16 @@ func (k *JPAKotlin) Generate(
 				if ref := column.Ref; ref != nil {
 					targetClassName := getClassNameByTable(ref.Table)
 					if len(targetClassName) == 0 {
-						log.Fatalf("Relation not found. %s::%s -> %s", class.Name, field.Name, ref.Table)
+						log.Printf("Relation not found. %s::%s -> %s\n", class.Name, field.Name, ref.Table)
+						appendLine(indent +
+							fmt.Sprintf("@VRelation(cls = \"%s\", field = \"%s\")",
+								class.Name,
+								strcase.ToLowerCamel(ref.Column)))
+					} else {
+						appendLine(indent +
+							fmt.Sprintf("@VRelation(cls = \"%s\", field = \"%s\")",
+								targetClassName,
+								strcase.ToLowerCamel(ref.Column)))
 					}
 
 					appendLine(indent +

--- a/fmt-jpa.go
+++ b/fmt-jpa.go
@@ -196,6 +196,7 @@ func (k *JPAKotlin) Generate(
 	reposPackage := output.Get(FlagReposPackage)
 	graphqlPackage := output.Get(FlagGraphqlPackage)
 	relation := output.Get(FlagRelation)
+	ignoreUnknownRelation := output.Get(FlagIgnoreUnknownRelation)
 	uniqueNameSuffix := output.Get(FlagUniqueNameSuffix)
 	idEntityInterfaceName := output.Get(FlagIdEntity)
 
@@ -318,11 +319,15 @@ func (k *JPAKotlin) Generate(
 				if ref := column.Ref; ref != nil {
 					targetClassName := getClassNameByTable(ref.Table)
 					if len(targetClassName) == 0 {
-						log.Printf("Relation not found. %s::%s -> %s\n", class.Name, field.Name, ref.Table)
-						appendLine(indent +
-							fmt.Sprintf("@VRelation(cls = \"%s\", field = \"%s\")",
-								strcase.ToCamel(ref.Table),
-								strcase.ToLowerCamel(ref.Column)))
+						if ignoreUnknownRelation == "true"{
+							log.Printf("Relation not found. %s::%s -> %s\n", class.Name, field.Name, ref.Table)
+							appendLine(indent +
+								fmt.Sprintf("@VRelation(cls = \"%s\", field = \"%s\")",
+									strcase.ToCamel(ref.Table),
+									strcase.ToLowerCamel(ref.Column)))
+						}else{
+							log.Fatalf("Relation not found. %s::%s -> %s\n", class.Name, field.Name, ref.Table)
+						}
 					} else {
 						appendLine(indent +
 							fmt.Sprintf("@VRelation(cls = \"%s\", field = \"%s\")",

--- a/fmt-jpa.go
+++ b/fmt-jpa.go
@@ -321,7 +321,7 @@ func (k *JPAKotlin) Generate(
 						log.Printf("Relation not found. %s::%s -> %s\n", class.Name, field.Name, ref.Table)
 						appendLine(indent +
 							fmt.Sprintf("@VRelation(cls = \"%s\", field = \"%s\")",
-								class.Name,
+								strcase.ToCamel(ref.Table),
 								strcase.ToLowerCamel(ref.Column)))
 					} else {
 						appendLine(indent +

--- a/main.go
+++ b/main.go
@@ -238,6 +238,11 @@ func main() {
 					EnvVar: "OCTOPUS_RELATION",
 				},
 				cli.StringFlag{
+					Name:	FlagIgnoreUnknownRelation,
+					Usage:	"ignore unknown relation",
+					EnvVar: "OCTOPUS_IGNORE_UNKNOWN_RELATION",
+				},
+				cli.StringFlag{
 					Name:   FlagAnnotation,
 					Usage:  "add custom class annotations",
 					EnvVar: "OCTOPUS_ANNOTATION",


### PR DESCRIPTION
When referring to a table not in the ojson file, it is displayed as the input table name and a message is displayed.